### PR TITLE
feat: Add reusable JSON data helper for Unity

### DIFF
--- a/Assets/Benetti/JsonDataHelper.cs
+++ b/Assets/Benetti/JsonDataHelper.cs
@@ -1,0 +1,81 @@
+using UnityEngine;
+using System;
+using System.IO;
+
+namespace Benetti
+{
+    /// <summary>
+    /// A static helper class for saving and loading data to and from JSON files.
+    /// Uses Unity's JsonUtility for serialization.
+    /// </summary>
+    public static class JsonDataHelper
+    {
+        /// <summary>
+        /// Saves the provided data object to a JSON file.
+        /// </summary>
+        /// <param name="data">The object to save. This object must be serializable by JsonUtility.</param>
+        /// <param name="fileName">The name of the file to save (e.g., "gamesettings.json").</param>
+        /// <typeparam name="T">The type of the data object.</typeparam>
+        public static void Save<T>(T data, string fileName)
+        {
+            // Get the full path to the file in a persistent data location
+            string path = Path.Combine(Application.persistentDataPath, fileName);
+
+            try
+            {
+                // Serialize the object to a JSON string with pretty print for readability
+                string json = JsonUtility.ToJson(data, true);
+
+                // Write the JSON string to the file
+                File.WriteAllText(path, json);
+
+                #if UNITY_EDITOR
+                Debug.Log($"Successfully saved data to {path}");
+                #endif
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to save data to {path}. Error: {e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Loads a data object from a JSON file.
+        /// If the file does not exist, it returns a new instance of the object.
+        /// </summary>
+        /// <param name="fileName">The name of the file to load.</param>
+        /// <typeparam name="T">The type of the data object to load. Must have a parameterless constructor.</typeparam>
+        /// <returns>The loaded data object, or a new instance if the file doesn't exist.</returns>
+        public static T Load<T>(string fileName) where T : new()
+        {
+            // Get the full path to the file
+            string path = Path.Combine(Application.persistentDataPath, fileName);
+
+            // If the file doesn't exist, return a default new instance
+            if (!File.Exists(path))
+            {
+                #if UNITY_EDITOR
+                Debug.LogWarning($"File not found at {path}. Returning a new default instance.");
+                #endif
+                return new T();
+            }
+
+            try
+            {
+                // Read the JSON string from the file
+                string json = File.ReadAllText(path);
+
+                // Deserialize the JSON string back into an object
+                T data = JsonUtility.FromJson<T>(json);
+
+                return data;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to load data from {path}. Error: {e.Message}. Returning a new default instance.");
+                // In case of error (e.g., corrupted file), return a default instance
+                return new T();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OptionsMenu.cs
+++ b/Assets/Scripts/OptionsMenu.cs
@@ -1,0 +1,121 @@
+using UnityEngine;
+using UnityEngine.Audio;
+using UnityEngine.UI;
+using TMPro;
+using Benetti; // Import the Benetti namespace to use the helper
+
+/// <summary>
+/// Manages the options menu UI and functionality.
+/// Relies on JsonDataHelper.cs for saving and loading settings.
+/// </summary>
+public class OptionsMenu : MonoBehaviour
+{
+    [Header("UI Element References")]
+    public Toggle FullscreenToggle;
+    public Toggle VSyncToggle;
+    public Toggle MuteAudioToggle;
+    public TMP_Dropdown QualityDropdown;
+    public TMP_Dropdown resolutionDropdown;
+    public Slider UiSoundsSlider;
+    public Slider MasterVolumeSlider;
+    public Slider MusicSlider;
+
+    [Header("Audio")]
+    public AudioMixer Mixer;
+
+    private SaveData _saveData;
+    private bool _settingsChanged;
+
+    private const string SAVE_FILE_NAME = "gamesettings.json";
+
+    void Start()
+    {
+        _settingsChanged = false;
+        LoadSettings(); // Load settings or create a default file
+
+        // --- Initialize UI Listeners ---
+        // These listeners update the settings in real-time and set the "dirty flag"
+        QualityDropdown.onValueChanged.AddListener(index => {
+            QualitySettings.SetQualityLevel(index, true);
+            _settingsChanged = true;
+        });
+        FullscreenToggle.onValueChanged.AddListener(value => {
+            Screen.fullScreenMode = value ? FullScreenMode.FullScreenWindow : FullScreenMode.Windowed;
+            _settingsChanged = true;
+        });
+        VSyncToggle.onValueChanged.AddListener(value => {
+            QualitySettings.vSyncCount = value ? 1 : 0;
+            _settingsChanged = true;
+        });
+
+        // Listeners for sliders and toggles that call the public methods below
+        MasterVolumeSlider.onValueChanged.AddListener(SetMasterVolume);
+        MusicSlider.onValueChanged.AddListener(SetMusicVolume);
+        UiSoundsSlider.onValueChanged.AddListener(SetUISoundVolume);
+        MuteAudioToggle.onValueChanged.AddListener(SetMute);
+    }
+
+    /// <summary>
+    /// A good place to save is when the menu is closed/disabled.
+    /// This method is automatically called by Unity when the GameObject is disabled.
+    /// </summary>
+    void OnDisable()
+    {
+        if (_settingsChanged)
+        {
+            SaveSettings();
+            _settingsChanged = false; // Reset flag
+        }
+    }
+
+    /// <summary>
+    /// Saves the current UI settings to a file using the JsonDataHelper.
+    /// </summary>
+    public void SaveSettings()
+    {
+        // Populate the SaveData object from the current UI state
+        _saveData.IsFullScreenOn = FullscreenToggle.isOn;
+        _saveData.IsVSyncOn = VSyncToggle.isOn;
+        _saveData.IsMutedOn = MuteAudioToggle.isOn;
+        _saveData.MasterVolume = MasterVolumeSlider.value;
+        _saveData.MusicVolume = MusicSlider.value;
+        _saveData.UISoundsVolume = UiSoundsSlider.value;
+        _saveData.ResolutionIndex = resolutionDropdown.value;
+        _saveData.QualitySetting = QualityDropdown.value;
+
+        // Use the helper to save the data to a file
+        JsonDataHelper.Save(_saveData, SAVE_FILE_NAME);
+        Debug.Log("Settings saved.");
+    }
+
+    /// <summary>
+    /// Loads settings from a file using the JsonDataHelper and applies them to the UI.
+    /// </summary>
+    public void LoadSettings()
+    {
+        // Use the helper to load the data
+        _saveData = JsonDataHelper.Load<SaveData>(SAVE_FILE_NAME);
+
+        // Apply the loaded settings to the UI
+        FullscreenToggle.isOn = _saveData.IsFullScreenOn;
+        VSyncToggle.isOn = _saveData.IsVSyncOn;
+        MuteAudioToggle.isOn = _saveData.IsMutedOn;
+        MasterVolumeSlider.value = _saveData.MasterVolume;
+        MusicSlider.value = _saveData.MusicVolume;
+        UiSoundsSlider.value = _saveData.UISoundsVolume;
+        resolutionDropdown.value = _saveData.ResolutionIndex;
+        QualityDropdown.value = _saveData.QualitySetting;
+
+        // Ensure audio is updated on load to reflect saved state
+        SetMasterVolume(_saveData.MasterVolume);
+        SetMusicVolume(_saveData.MusicVolume);
+        SetUISoundVolume(_saveData.UISoundsVolume);
+        SetMute(_saveData.IsMutedOn);
+    }
+
+    // --- Public methods to be called by listeners ---
+    public void SetMasterVolume(float value) { Mixer.SetFloat("MasterVolume", value > 0 ? Mathf.Log10(value) * 20 : -80f); _settingsChanged = true; }
+    public void SetMusicVolume(float value) { Mixer.SetFloat("MusicVolume", value > 0 ? Mathf.Log10(value) * 20 : -80f); _settingsChanged = true; }
+    public void SetUISoundVolume(float value) { Mixer.SetFloat("UIsoundsVolume", value > 0 ? Mathf.Log10(value) * 20 : -80f); _settingsChanged = true; }
+    public void SetMute(bool isMuted) { Mixer.SetFloat("MasterVolume", isMuted ? -80f : Mathf.Log10(MasterVolumeSlider.value) * 20); _settingsChanged = true; }
+}

--- a/Assets/Scripts/SaveData.cs
+++ b/Assets/Scripts/SaveData.cs
@@ -1,0 +1,16 @@
+/// <summary>
+/// A simple data class to hold settings for JSON serialization.
+/// This class uses public fields instead of properties to be compatible with Unity's JsonUtility.
+/// </summary>
+[System.Serializable]
+public class SaveData
+{
+    public bool IsFullScreenOn = true;
+    public bool IsVSyncOn = true;
+    public bool IsMutedOn = false;
+    public float MasterVolume = 1.0f;
+    public float MusicVolume = 0.8f;
+    public float UISoundsVolume = 1.0f;
+    public int ResolutionIndex = 0;
+    public int QualitySetting = 2; // Default to "Medium" or similar
+}


### PR DESCRIPTION
This commit introduces a new static helper class, `JsonDataHelper`, to simplify saving and loading data to JSON files in a Unity project.

The helper is located in the `Benetti` namespace for easy reuse across different projects. It provides two generic static methods:
- `Save<T>(T data, string fileName)`
- `Load<T>(string fileName)`

It uses Unity's built-in `JsonUtility` for serialization, ensuring maximum compatibility without external dependencies. The `Save` method pretty-prints the JSON for readability. The `Load` method safely handles cases where the save file does not yet exist by returning a new object instance.

Also included are the `OptionsMenu.cs` and `SaveData.cs` scripts, based on the user's request, to serve as a complete, working example of how to use the helper.